### PR TITLE
Update network diagram colors to match OTel branding

### DIFF
--- a/src/Example.Spa/src/app/components/network-diagram/network-diagram.component.html
+++ b/src/Example.Spa/src/app/components/network-diagram/network-diagram.component.html
@@ -42,7 +42,7 @@
     </div>
 
     <!-- SVG for connection lines and animations -->
-    <svg class="connections-svg" viewBox="0 -30 800 700" preserveAspectRatio="xMidYMid meet">
+    <svg class="connections-svg" viewBox="0 -30 900 780" preserveAspectRatio="xMidYMid meet">
       <defs>
         <!-- Photon glow filter -->
         <filter id="photonGlow" x="-50%" y="-50%" width="200%" height="200%">
@@ -52,28 +52,39 @@
             <feMergeNode in="SourceGraphic"/>
           </feMerge>
         </filter>
+        <!-- Red pill gradient for "You" badge -->
+        <linearGradient id="redPillGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" style="stop-color:#E91E63"/>
+          <stop offset="100%" style="stop-color:#F44336"/>
+        </linearGradient>
       </defs>
 
+      <!-- Developer Workstation Border - left side container -->
+      <rect x="5" y="100" width="260" height="520" rx="16" ry="16" class="developer-workstation-border"/>
+      <text x="135" y="125" class="developer-workstation-label">Developer Workstation</text>
+      <!-- "You" red pill badge -->
+      <rect x="205" y="93" width="50" height="16" rx="8" ry="8" class="developer-workstation-badge"/>
+      <text x="230" y="104" fill="white" font-size="9" font-weight="700" text-anchor="middle" letter-spacing="0.5" style="text-transform: uppercase;">You</text>
+
       <!-- Chaos Sandbox Border - resizes when Coming Soon is enabled -->
-      <!-- Bottom stays at y=410, top expands upward when Coming Soon is enabled -->
-      <rect x="320"
+      <rect x="300"
             [attr.y]="showComingSoon ? 5 : 150"
-            width="480"
-            [attr.height]="showComingSoon ? 405 : 260"
+            width="590"
+            [attr.height]="showComingSoon ? 300 : 260"
             rx="20" ry="20"
             class="chaos-sandbox-border"/>
-      <text x="560" [attr.y]="showComingSoon ? 35 : 180" class="chaos-sandbox-label">Chaos Sandbox</text>
+      <text x="595" [attr.y]="showComingSoon ? 35 : 180" class="chaos-sandbox-label">Chaos Sandbox</text>
 
       <!-- Connection Lines -->
       <!-- Client to API (always healthy) -->
-      <line x1="80" y1="250" x2="400" y2="250"
+      <line x1="265" y1="300" x2="500" y2="300"
             class="connection-line line-healthy"/>
 
       <!-- API to SQL - invisible hit area + visible line -->
-      <line x1="400" y1="250" x2="720" y2="220"
+      <line x1="500" y1="300" x2="820" y2="270"
             class="connection-hit-area"
             (click)="onConnectionClick(getConnectionForResource('sql')!)"/>
-      <line x1="400" y1="250" x2="720" y2="220"
+      <line x1="500" y1="300" x2="820" y2="270"
             class="connection-line"
             [class.line-healthy]="getConnectionForResource('sql')?.status === 'healthy'"
             [class.line-broken]="getConnectionForResource('sql')?.status === 'broken'"
@@ -81,10 +92,10 @@
             (click)="onConnectionClick(getConnectionForResource('sql')!)"/>
 
       <!-- API to Redis - invisible hit area + visible line -->
-      <line x1="400" y1="250" x2="720" y2="350"
+      <line x1="500" y1="300" x2="820" y2="380"
             class="connection-hit-area"
             (click)="onConnectionClick(getConnectionForResource('redis')!)"/>
-      <line x1="400" y1="250" x2="720" y2="350"
+      <line x1="500" y1="300" x2="820" y2="380"
             class="connection-line"
             [class.line-healthy]="getConnectionForResource('redis')?.status === 'healthy'"
             [class.line-broken]="getConnectionForResource('redis')?.status === 'broken'"
@@ -92,54 +103,66 @@
             (click)="onConnectionClick(getConnectionForResource('redis')!)"/>
 
       <!-- Message Worker to Message Broker (Coming Soon) - horizontal bidirectional -->
-      <line *ngIf="showComingSoon" x1="460" y1="97" x2="645" y2="97"
+      <line *ngIf="showComingSoon" x1="560" y1="97" x2="745" y2="97"
             class="connection-line line-coming-soon"/>
-      <line *ngIf="showComingSoon" x1="645" y1="103" x2="460" y2="103"
+      <line *ngIf="showComingSoon" x1="745" y1="103" x2="560" y2="103"
             class="connection-line line-coming-soon"/>
 
       <!-- Message Broker to API (Coming Soon) - diagonal bidirectional -->
-      <line *ngIf="showComingSoon" x1="720" y1="135" x2="430" y2="210"
+      <line *ngIf="showComingSoon" x1="820" y1="135" x2="530" y2="260"
             class="connection-line line-coming-soon"/>
-      <line *ngIf="showComingSoon" x1="420" y1="210" x2="710" y2="135"
+      <line *ngIf="showComingSoon" x1="520" y1="260" x2="810" y2="135"
             class="connection-line line-coming-soon"/>
 
       <!-- API to OpenTelemetry -->
-      <line x1="400" y1="300" x2="400" y2="440"
-            class="connection-line line-telemetry"/>
+      <line x1="500" y1="350" x2="500" y2="440"
+            class="connection-line line-otel-out"/>
 
       <!-- SQL to OpenTelemetry (optional curved line) -->
       <path *ngIf="showOptionalCapabilities"
-            d="M 720 220 Q 620 400 400 470"
+            d="M 820 270 Q 700 400 570 450"
             class="connection-line line-telemetry-sql"/>
 
       <!-- Redis to OpenTelemetry (optional curved line) -->
       <path *ngIf="showOptionalCapabilities"
-            d="M 720 350 Q 600 450 400 470"
+            d="M 820 380 Q 680 420 570 460"
             class="connection-line line-telemetry-redis"/>
 
-      <!-- OpenTelemetry to Immersive APM -->
-      <line x1="400" y1="520" x2="280" y2="590"
-            class="connection-line line-telemetry"/>
+      <!-- OpenTelemetry to Immersive APM Backend (external cloud service) -->
+      <line x1="500" y1="530" x2="500" y2="545"
+            class="connection-line line-otel-out"/>
 
-      <!-- OpenTelemetry to Others -->
-      <line x1="400" y1="520" x2="520" y2="590"
-            class="connection-line line-others"/>
+      <!-- OpenTelemetry to Other APM Backends (external cloud service) -->
+      <line x1="570" y1="500" x2="620" y2="570"
+            class="connection-line line-otel-out"/>
+
+      <!-- Immersive APM Backend to IAPM Desktop (feeds dev workstation) -->
+      <line x1="430" y1="590" x2="255" y2="480"
+            class="connection-line line-otel-out"/>
+
+      <!-- Immersive APM Backend to IAPM Web (also available via web) -->
+      <line x1="430" y1="600" x2="255" y2="545"
+            class="connection-line line-otel-out"/>
+
+      <!-- Other APM Backends to Other APM Tools (feeds dev workstation) -->
+      <path d="M 620 650 Q 400 750 255 595"
+            class="connection-line line-otel-out" fill="none"/>
 
       <!-- Break indicators (clickable to fix) -->
-      <!-- SQL break indicator at midpoint of line from (400,250) to (720,220) = (560, 235) -->
+      <!-- SQL break indicator at midpoint of line from (500,300) to (820,270) = (660, 285) -->
       <g *ngIf="getConnectionForResource('sql')?.status === 'broken'"
          class="break-indicator-svg clickable"
          (click)="onConnectionClick(getConnectionForResource('sql')!)">
-        <circle cx="560" cy="235" r="14" fill="#f44336" class="break-pulse"/>
-        <text x="560" y="240" text-anchor="middle" fill="white" font-size="14" font-weight="bold">✕</text>
+        <circle cx="660" cy="285" r="14" fill="#f44336" class="break-pulse"/>
+        <text x="660" y="290" text-anchor="middle" fill="white" font-size="14" font-weight="bold">✕</text>
       </g>
 
-      <!-- Redis break indicator at midpoint of line from (400,250) to (720,350) = (560, 300) -->
+      <!-- Redis break indicator at midpoint of line from (500,300) to (820,380) = (660, 340) -->
       <g *ngIf="getConnectionForResource('redis')?.status === 'broken'"
          class="break-indicator-svg clickable"
          (click)="onConnectionClick(getConnectionForResource('redis')!)">
-        <circle cx="560" cy="300" r="14" fill="#f44336" class="break-pulse"/>
-        <text x="560" y="305" text-anchor="middle" fill="white" font-size="14" font-weight="bold">✕</text>
+        <circle cx="660" cy="340" r="14" fill="#f44336" class="break-pulse"/>
+        <text x="660" y="345" text-anchor="middle" fill="white" font-size="14" font-weight="bold">✕</text>
       </g>
 
       <!-- Request dot (photon) -->
@@ -154,55 +177,83 @@
                 filter="url(#photonGlow)"/>
       }
 
-      <!-- Telemetry dot -->
+      <!-- Telemetry dot (API to OTel - blue to match OTel branding) -->
       @if (telemetryDotVisible) {
         <circle [attr.cx]="getTelemetryDotSvgPosition().x"
                 [attr.cy]="getTelemetryDotSvgPosition().y"
                 r="6"
-                fill="#FF6D00"
+                fill="#425CC7"
                 class="telemetry-dot-svg"
                 filter="url(#photonGlow)"/>
       }
 
-      <!-- Immersive APM dot -->
+      <!-- Immersive APM dot (blue to match OTel branding) -->
       @if (immersiveApmDotVisible) {
         <circle [attr.cx]="getImmersiveApmDotSvgPosition().x"
                 [attr.cy]="getImmersiveApmDotSvgPosition().y"
                 r="6"
-                fill="#FF6D00"
+                fill="#425CC7"
                 class="telemetry-dot-svg"
                 filter="url(#photonGlow)"/>
       }
 
-      <!-- Others dot (gray hollow) -->
+      <!-- Others dot (blue to match OTel branding) -->
       @if (othersDotVisible) {
         <circle [attr.cx]="getOthersDotSvgPosition().x"
                 [attr.cy]="getOthersDotSvgPosition().y"
                 r="6"
-                fill="none"
-                stroke="#9E9E9E"
-                stroke-width="2"
+                fill="#425CC7"
                 class="others-dot-svg"
                 filter="url(#photonGlow)"/>
       }
 
-      <!-- SQL telemetry dot (optional - follows curved path) -->
+      <!-- SQL telemetry dot (optional - follows curved path, blue to match OTel) -->
       @if (sqlTelemetryDotVisible && showOptionalCapabilities) {
         <circle [attr.cx]="getSqlTelemetryDotSvgPosition().x"
                 [attr.cy]="getSqlTelemetryDotSvgPosition().y"
                 r="5"
-                fill="#4CAF50"
+                fill="#425CC7"
                 class="sql-telemetry-dot-svg"
                 filter="url(#photonGlow)"/>
       }
 
-      <!-- Redis telemetry dot (optional - follows curved path) -->
+      <!-- Redis telemetry dot (optional - follows curved path, blue to match OTel) -->
       @if (redisTelemetryDotVisible && showOptionalCapabilities) {
         <circle [attr.cx]="getRedisTelemetryDotSvgPosition().x"
                 [attr.cy]="getRedisTelemetryDotSvgPosition().y"
                 r="5"
-                fill="#FF9800"
+                fill="#425CC7"
                 class="redis-telemetry-dot-svg"
+                filter="url(#photonGlow)"/>
+      }
+
+      <!-- IAPM Desktop dot (from IAPM Cloud to Desktop) - blue to match OTel branding -->
+      @if (iapmDesktopDotVisible) {
+        <circle [attr.cx]="getIapmDesktopDotSvgPosition().x"
+                [attr.cy]="getIapmDesktopDotSvgPosition().y"
+                r="6"
+                fill="#425CC7"
+                class="iapm-desktop-dot-svg"
+                filter="url(#photonGlow)"/>
+      }
+
+      <!-- IAPM Web dot (from IAPM Cloud to Web) - blue to match OTel branding -->
+      @if (iapmWebDotVisible) {
+        <circle [attr.cx]="getIapmWebDotSvgPosition().x"
+                [attr.cy]="getIapmWebDotSvgPosition().y"
+                r="6"
+                fill="#425CC7"
+                class="iapm-web-dot-svg"
+                filter="url(#photonGlow)"/>
+      }
+
+      <!-- Others Client dot (from Other Plumbing to Other Tools) - blue to match OTel -->
+      @if (othersClientDotVisible) {
+        <circle [attr.cx]="getOthersClientDotSvgPosition().x"
+                [attr.cy]="getOthersClientDotSvgPosition().y"
+                r="6"
+                fill="#425CC7"
+                class="others-client-dot-svg"
                 filter="url(#photonGlow)"/>
       }
 
@@ -219,15 +270,14 @@
       </g>
 
       <!-- HTML Nodes inside SVG using foreignObject -->
-      <!-- Client Node with embedded flows -->
-      <foreignObject x="-5" y="140" [attr.height]="getClientNodeHeight()" width="250">
+      <!-- Client Node with embedded flows (inside Developer Workstation) -->
+      <foreignObject x="15" y="135" [attr.height]="getClientNodeHeight()" width="240">
         <div xmlns="http://www.w3.org/1999/xhtml" class="node node-client"
              [class.status-processing]="getNode('client')?.status === 'processing'"
              [class.status-success]="getNode('client')?.status === 'success'"
              [class.status-error]="getNode('client')?.status === 'error'">
-          <span class="node-badge">You</span>
-          <span class="node-icon"><i class="fas fa-user"></i></span>
-          <span class="node-label">Client</span>
+          <span class="node-icon"><i class="fas fa-globe"></i></span>
+          <span class="node-label">Browser</span>
 
           <!-- SQL Flow Section -->
           <div class="flow-section sql-section">
@@ -302,8 +352,8 @@
         </div>
       </foreignObject>
 
-      <!-- API Node: Line ends at x=400, so center node there (x = 400 - width/2 = 400 - 60 = 340) -->
-      <foreignObject x="340" y="200" width="120" height="100">
+      <!-- API Node: Line ends at x=500, so center node there -->
+      <foreignObject x="440" y="250" width="120" height="100">
         <div xmlns="http://www.w3.org/1999/xhtml" class="node node-api"
              [class.status-processing]="getNode('api')?.status === 'processing'"
              [class.status-success]="getNode('api')?.status === 'success'"
@@ -314,8 +364,8 @@
         </div>
       </foreignObject>
 
-      <!-- SQL Node: Line ends at x=720, so center node there (x = 720 - width/2 = 720 - 70 = 650) -->
-      <foreignObject x="650" y="170" width="140" height="100">
+      <!-- SQL Node: Line ends at x=820 -->
+      <foreignObject x="750" y="220" width="140" height="100">
         <div xmlns="http://www.w3.org/1999/xhtml" class="node node-database"
              [class.status-processing]="getNode('sql')?.status === 'processing'"
              [class.status-success]="getNode('sql')?.status === 'success'"
@@ -326,8 +376,8 @@
         </div>
       </foreignObject>
 
-      <!-- Redis Node: Line ends at x=720, so center node there (x = 720 - width/2 = 720 - 70 = 650) -->
-      <foreignObject x="650" y="300" width="140" height="100">
+      <!-- Redis Node: Line ends at x=820 -->
+      <foreignObject x="750" y="330" width="140" height="100">
         <div xmlns="http://www.w3.org/1999/xhtml" class="node node-cache"
              [class.status-processing]="getNode('redis')?.status === 'processing'"
              [class.status-success]="getNode('redis')?.status === 'success'"
@@ -338,8 +388,8 @@
         </div>
       </foreignObject>
 
-      <!-- Message Broker Node (Coming Soon): Line ends at x=720 -->
-      <foreignObject *ngIf="showComingSoon" x="645" y="60" width="150" height="75">
+      <!-- Message Broker Node (Coming Soon) -->
+      <foreignObject *ngIf="showComingSoon" x="745" y="60" width="150" height="75">
         <div xmlns="http://www.w3.org/1999/xhtml" class="node node-message-broker coming-soon"
              title="Message Broker&#10;Asynchronous messaging system for decoupled communication. Enables pub/sub and queue-based patterns.">
           <span class="coming-soon-badge">Coming Soon</span>
@@ -348,8 +398,8 @@
         </div>
       </foreignObject>
 
-      <!-- Worker Node (Coming Soon): Line starts at x=400 -->
-      <foreignObject *ngIf="showComingSoon" x="340" y="60" width="120" height="75">
+      <!-- Worker Node (Coming Soon) -->
+      <foreignObject *ngIf="showComingSoon" x="440" y="60" width="120" height="75">
         <div xmlns="http://www.w3.org/1999/xhtml" class="node node-message-worker coming-soon"
              title="Background Worker&#10;Processes async jobs from the message broker. Handles long-running tasks outside the request cycle.">
           <span class="coming-soon-badge">Coming Soon</span>
@@ -358,8 +408,8 @@
         </div>
       </foreignObject>
 
-      <!-- OpenTelemetry Node: Lines connect at x=400, y=380-420 range -->
-      <foreignObject x="330" y="430" width="140" height="90">
+      <!-- OpenTelemetry Node -->
+      <foreignObject x="430" y="440" width="140" height="90">
         <div xmlns="http://www.w3.org/1999/xhtml" class="node node-telemetry"
              [class.status-processing]="getNode('otel')?.status === 'processing'"
              [class.status-success]="getNode('otel')?.status === 'success'"
@@ -370,27 +420,57 @@
         </div>
       </foreignObject>
 
-      <!-- Immersive APM Node: Line ends at x=280 y=530 -->
-      <foreignObject x="205" y="550" width="150" height="90">
-        <div xmlns="http://www.w3.org/1999/xhtml" class="node node-telemetry"
+      <!-- Immersive APM Backend (external cloud service - NOT in sandbox) -->
+      <foreignObject x="430" y="545" width="140" height="90">
+        <div xmlns="http://www.w3.org/1999/xhtml" class="node node-iapm-backend"
              [class.status-processing]="getNode('immersive-apm')?.status === 'processing'"
              [class.status-success]="getNode('immersive-apm')?.status === 'success'"
              [class.status-error]="getNode('immersive-apm')?.status === 'error'"
-             title="Immersive APM&#10;3D visualization of your application's telemetry data for intuitive performance monitoring.">
-          <span class="node-icon"><i class="fas fa-cube"></i></span>
-          <span class="node-label">Immersive APM</span>
+             title="Immersive APM Cloud&#10;Cloud-native telemetry storage and processing with real-time 3D visualization engine.">
+          <span class="node-icon"><i class="fas fa-cloud"></i></span>
+          <span class="node-label">IAPM Cloud</span>
         </div>
       </foreignObject>
 
-      <!-- Others Node: Line ends at x=520 y=530 -->
-      <foreignObject x="460" y="550" width="120" height="90">
-        <div xmlns="http://www.w3.org/1999/xhtml" class="node node-others"
+      <!-- Other APM Backends (external cloud services - NOT in sandbox) -->
+      <foreignObject x="620" y="570" width="140" height="90">
+        <div xmlns="http://www.w3.org/1999/xhtml" class="node node-others-backend"
              [class.status-processing]="getNode('others')?.status === 'processing'"
              [class.status-success]="getNode('others')?.status === 'success'"
              [class.status-error]="getNode('others')?.status === 'error'"
-             title="Other Backends&#10;OpenTelemetry can export to many backends: Jaeger, Zipkin, Prometheus, and more.">
-          <span class="node-icon"><i class="fas fa-ellipsis-h"></i></span>
-          <span class="node-label">Others</span>
+             title="Other APM Backends&#10;Traditional APM cloud services: Datadog, New Relic, Dynatrace, etc.">
+          <span class="node-icon"><i class="fas fa-question-circle"></i></span>
+          <span class="node-label">Other Plumbing</span>
+        </div>
+      </foreignObject>
+
+      <!-- IAPM Desktop (in Developer Workstation - modern/cool) -->
+      <foreignObject x="15" y="440" width="240" height="70">
+        <div xmlns="http://www.w3.org/1999/xhtml" class="node node-iapm-desktop"
+             title="Immersive APM Desktop&#10;Next-gen 3D visualization app for exploring distributed traces in immersive environments.">
+          <span class="node-badge-modern">Immersive :)</span>
+          <span class="node-icon"><i class="fas fa-cube"></i></span>
+          <span class="node-label">IAPM Desktop</span>
+        </div>
+      </foreignObject>
+
+      <!-- IAPM Web (in Developer Workstation - also modern) -->
+      <foreignObject x="15" y="520" width="240" height="45">
+        <div xmlns="http://www.w3.org/1999/xhtml" class="node node-iapm-web"
+             title="Immersive APM Web&#10;Browser-based 3D trace visualization.">
+          <span class="node-badge-browser">Browser</span>
+          <span class="node-icon"><i class="fas fa-globe"></i></span>
+          <span class="node-label">IAPM Web</span>
+        </div>
+      </foreignObject>
+
+      <!-- Other APM Tools (in Developer Workstation - legacy/boring) -->
+      <foreignObject x="15" y="570" width="240" height="45">
+        <div xmlns="http://www.w3.org/1999/xhtml" class="node node-others-legacy"
+             title="Traditional APM UIs&#10;Web dashboards, CLI tools, and basic 2D visualizations.">
+          <span class="node-badge-browser">Browser</span>
+          <span class="node-icon"><i class="fas fa-window-maximize"></i></span>
+          <span class="node-label">Other Tools</span>
         </div>
       </foreignObject>
     </svg>

--- a/src/Example.Spa/src/app/components/network-diagram/network-diagram.component.scss
+++ b/src/Example.Spa/src/app/components/network-diagram/network-diagram.component.scss
@@ -173,8 +173,8 @@ $color-chaos-sandbox: rgba(156, 39, 176, 0.3);  // Faint purple for chaos sandbo
   }
 
   &.telemetry {
-    background: rgba($color-telemetry, 0.15);
-    color: $color-telemetry;
+    background: rgba(#78909C, 0.15);
+    color: #90A4AE;
   }
 }
 
@@ -190,16 +190,16 @@ $color-chaos-sandbox: rgba(156, 39, 176, 0.3);  // Faint purple for chaos sandbo
   animation: tickerFadeIn 0.2s ease-out;
 
   &.telemetry {
-    border-color: rgba($color-telemetry, 0.5);
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3), 0 0 10px rgba($color-telemetry, 0.15);
+    border-color: rgba(#78909C, 0.5);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3), 0 0 10px rgba(#78909C, 0.15);
 
     .ticker-step {
-      background: rgba($color-telemetry, 0.3);
-      color: $color-telemetry;
+      background: rgba(#78909C, 0.3);
+      color: #90A4AE;
     }
 
     .ticker-text {
-      color: rgba($color-telemetry, 0.9);
+      color: rgba(#B0BEC5, 0.9);
     }
   }
 
@@ -253,6 +253,31 @@ $color-chaos-sandbox: rgba(156, 39, 176, 0.3);  // Faint purple for chaos sandbo
   }
 }
 
+// Developer Workstation border
+.developer-workstation-border {
+  fill: rgba(33, 150, 243, 0.08);
+  stroke: rgba(33, 150, 243, 0.4);
+  stroke-width: 2;
+  stroke-dasharray: none;
+  pointer-events: none;
+}
+
+.developer-workstation-label {
+  fill: rgba(33, 150, 243, 0.7);
+  font-size: 11px;
+  font-weight: 600;
+  text-anchor: middle;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+// "You" badge for Developer Workstation (red pill style)
+.developer-workstation-badge {
+  fill: url(#redPillGradient);
+  filter: drop-shadow(0 2px 4px rgba(244, 67, 54, 0.5));
+}
+
 // Chaos Sandbox border
 .chaos-sandbox-border {
   fill: none;
@@ -272,9 +297,15 @@ $color-chaos-sandbox: rgba(156, 39, 176, 0.3);  // Faint purple for chaos sandbo
   pointer-events: none;
 }
 
-// foreignObject nodes need pointer-events enabled
+// foreignObject nodes - disable pointer events on the container, enable on content
 foreignObject {
   overflow: visible;
+  pointer-events: none;
+
+  // Enable pointer events only on the actual node content
+  .node {
+    pointer-events: auto;
+  }
 
   // Bring hovered foreignObject to front for tooltips
   &:hover {
@@ -347,6 +378,32 @@ foreignObject {
     animation: telemetryDash 0.6s linear infinite;
   }
 
+  // OpenTelemetry outbound lines (orange to match OTel branding)
+  &.line-otel-out {
+    stroke: #F5A623;
+    stroke-width: 2;
+    stroke-dasharray: 5 5;
+    opacity: 0.7;
+    animation: telemetryDash 0.6s linear infinite;
+  }
+
+  &.line-iapm-client {
+    stroke: #F5A623;
+    stroke-width: 2;
+    stroke-dasharray: 5 5;
+    opacity: 0.7;
+    animation: telemetryDash 0.6s linear infinite;
+    filter: drop-shadow(0 0 6px rgba(245, 166, 35, 0.5));
+  }
+
+  &.line-others-client {
+    stroke: #607D8B;
+    stroke-width: 1;
+    stroke-dasharray: 3 3;
+    opacity: 0.4;
+    animation: telemetryDash 0.8s linear infinite;
+  }
+
   &.line-coming-soon {
     stroke: $color-message-broker;
     stroke-width: 2;
@@ -404,27 +461,24 @@ foreignObject {
   }
 }
 
-// Telemetry dot
+// Telemetry dot - fill set via inline attribute (#425CC7 blue for OTel branding)
 .telemetry-dot-svg {
-  fill: $color-telemetry;
-  filter: drop-shadow(0 0 8px $color-telemetry);
+  filter: drop-shadow(0 0 8px #425CC7);
 }
 
-// Others dot (gray hollow)
+// Others dot - fill set via inline attribute (#425CC7 blue for OTel branding)
 .others-dot-svg {
-  filter: drop-shadow(0 0 6px #9E9E9E);
+  filter: drop-shadow(0 0 6px #425CC7);
 }
 
-// SQL telemetry dot (green)
+// SQL telemetry dot - fill set via inline attribute (#425CC7 blue for OTel branding)
 .sql-telemetry-dot-svg {
-  fill: $color-healthy;
-  filter: drop-shadow(0 0 8px $color-healthy);
+  filter: drop-shadow(0 0 8px #425CC7);
 }
 
-// Redis telemetry dot (orange)
+// Redis telemetry dot - fill set via inline attribute (#425CC7 blue for OTel branding)
 .redis-telemetry-dot-svg {
-  fill: $color-warning;
-  filter: drop-shadow(0 0 8px $color-warning);
+  filter: drop-shadow(0 0 8px #425CC7);
 }
 
 // Explosion
@@ -503,23 +557,6 @@ foreignObject {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 20px rgba($color-request, 0.3);
   padding: 12px 12px;
   position: relative;
-
-  .node-badge {
-    position: absolute;
-    top: -10px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: $color-request;
-    color: white;
-    font-size: 10px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 3px 10px;
-    border-radius: 10px;
-    white-space: nowrap;
-    box-shadow: 0 2px 8px rgba($color-request, 0.5);
-  }
 }
 
 // Flow Section - embedded in client node
@@ -731,24 +768,206 @@ foreignObject {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 20px rgba(#9C27B0, 0.3);
 }
 
+// SQL Database - Azure SQL branding (blue)
 .node-database {
-  border-color: $color-healthy;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 20px rgba($color-healthy, 0.3);
+  border-color: #0078D4;
+  background: rgba(0, 120, 212, 0.15);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 20px rgba(0, 120, 212, 0.3);
+
+  .node-icon {
+    color: #0078D4;
+    text-shadow: 0 0 10px rgba(0, 120, 212, 0.5);
+  }
+
+  .node-label {
+    color: #fff;
+    font-weight: 600;
+  }
 }
 
+// Redis - Redis branding (red)
 .node-cache {
-  border-color: $color-warning;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 20px rgba($color-warning, 0.3);
+  border-color: #DC382D;
+  background: rgba(220, 56, 45, 0.15);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 20px rgba(220, 56, 45, 0.3);
+
+  .node-icon {
+    color: #DC382D;
+    text-shadow: 0 0 10px rgba(220, 56, 45, 0.5);
+  }
+
+  .node-label {
+    color: #fff;
+    font-weight: 600;
+  }
 }
 
+// OpenTelemetry - OTel branding (orange/blue)
 .node-telemetry {
-  border-color: $color-telemetry;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 20px rgba($color-telemetry, 0.3);
+  border-color: #F5A623;
+  border-width: 2px;
+  background: linear-gradient(135deg, rgba(245, 166, 35, 0.15) 0%, rgba(66, 92, 199, 0.15) 100%);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 20px rgba(245, 166, 35, 0.3);
+
+  .node-icon {
+    color: #F5A623;
+    text-shadow: 0 0 10px rgba(245, 166, 35, 0.5);
+  }
+
+  .node-label {
+    color: #fff;
+    font-weight: 600;
+  }
 }
 
 .node-others {
   border-color: #9E9E9E;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 20px rgba(#9E9E9E, 0.3);
+}
+
+// IAPM Cloud - Immersive APM branding (cyan/magenta gradient)
+.node-iapm-backend {
+  border-color: #00BCD4;
+  border-width: 2px;
+  background: linear-gradient(135deg, rgba(0, 188, 212, 0.15) 0%, rgba(156, 39, 176, 0.15) 100%);
+  box-shadow:
+    0 4px 20px rgba(0, 0, 0, 0.5),
+    0 0 25px rgba(0, 188, 212, 0.3),
+    0 0 40px rgba(156, 39, 176, 0.15);
+
+  .node-icon {
+    color: #00E5FF;
+    text-shadow: 0 0 15px rgba(0, 229, 255, 0.6);
+  }
+
+  .node-label {
+    color: #fff;
+    font-weight: 600;
+    text-shadow: 0 0 8px rgba(0, 229, 255, 0.4);
+  }
+}
+
+.node-others-backend {
+  border-color: #78909C;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5), 0 0 15px rgba(#78909C, 0.2);
+}
+
+// IAPM Desktop - Modern, cool, vibrant
+.node-iapm-desktop {
+  border-color: #00BCD4;
+  border-width: 2px;
+  background: linear-gradient(135deg, rgba(0, 188, 212, 0.2) 0%, rgba(156, 39, 176, 0.2) 100%);
+  box-shadow:
+    0 4px 20px rgba(0, 0, 0, 0.5),
+    0 0 30px rgba(0, 188, 212, 0.4),
+    0 0 60px rgba(156, 39, 176, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  position: relative;
+  overflow: visible;
+
+  .node-icon {
+    color: #00E5FF;
+    font-size: 1.6rem;
+    text-shadow: 0 0 20px rgba(0, 229, 255, 0.8);
+  }
+
+  .node-label {
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: #fff;
+    text-shadow: 0 0 10px rgba(0, 229, 255, 0.6), 0 1px 2px rgba(0, 0, 0, 0.8);
+  }
+
+  .node-tagline {
+    font-size: 0.6rem;
+    color: rgba(0, 229, 255, 0.9);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-top: 2px;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  }
+
+  .node-badge-modern {
+    position: absolute;
+    top: -8px;
+    right: 10px;
+    background: linear-gradient(90deg, #00BCD4, #9C27B0);
+    color: white;
+    font-size: 0.55rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 2px 8px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 188, 212, 0.5);
+  }
+}
+
+// IAPM Web - Also modern but simpler
+.node-iapm-web {
+  border-color: #00BCD4;
+  border-width: 1px;
+  background: linear-gradient(135deg, rgba(0, 188, 212, 0.1) 0%, rgba(156, 39, 176, 0.1) 100%);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4), 0 0 15px rgba(0, 188, 212, 0.2);
+  flex-direction: row;
+  gap: 8px;
+  padding: 8px 12px;
+  position: relative;
+  overflow: visible;
+
+  .node-icon {
+    color: #00BCD4;
+    font-size: 1rem;
+    margin-bottom: 0;
+  }
+
+  .node-label {
+    font-weight: 600;
+    font-size: 0.75rem;
+    color: #00E5FF;
+  }
+}
+
+// Browser badge for web-based APM tools (positioned like Immersive badge)
+.node-badge-browser {
+  position: absolute;
+  top: -8px;
+  right: 10px;
+  background: #607D8B;
+  color: white;
+  font-size: 0.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
+// Other APM Tools - Legacy, boring, muted
+.node-others-legacy {
+  border-color: #607D8B;
+  border-width: 1px;
+  border-style: solid;
+  background: rgba(55, 71, 79, 0.6);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  flex-direction: row;
+  gap: 8px;
+  padding: 8px 12px;
+  position: relative;
+  overflow: visible;
+
+  .node-icon {
+    color: #90A4AE;
+    font-size: 1rem;
+    margin-bottom: 0;
+  }
+
+  .node-label {
+    color: #B0BEC5;
+    font-weight: 400;
+    font-size: 0.75rem;
+  }
 }
 
 .node-message-broker {

--- a/src/Example.Spa/src/app/components/network-diagram/network-diagram.component.ts
+++ b/src/Example.Spa/src/app/components/network-diagram/network-diagram.component.ts
@@ -32,17 +32,19 @@ export interface RequestFlow {
 }
 
 // SVG coordinate positions for each node (matches SVG line endpoints)
-// Based on viewBox="0 0 800 650" - aligned with HTML node positions
+// Based on viewBox="0 -30 900 700" - aligned with HTML node positions
 const NODE_POSITIONS: { [key: string]: { x: number; y: number } } = {
-  'client': { x: 80, y: 250 },   // Left side (10%), middle
-  'api': { x: 400, y: 250 },     // Center (50%), same height as client
-  'sql': { x: 720, y: 220 },     // Right side (90%), above API
-  'redis': { x: 720, y: 350 },   // Right side (90%), below API
-  'message-broker': { x: 720, y: 100 },   // Right side (90%), top
-  'message-worker': { x: 400, y: 100 },   // Center (50%), top
-  'otel': { x: 400, y: 520 },    // Center (50%), below API - matches line endpoint
-  'immersive-apm': { x: 280, y: 590 },  // Left-center (35%), bottom
-  'others': { x: 520, y: 590 }          // Right-center (65%), bottom
+  'client': { x: 265, y: 300 },   // Developer workstation right edge
+  'api': { x: 500, y: 300 },      // Center of sandbox
+  'sql': { x: 820, y: 270 },      // Right side, above API
+  'redis': { x: 820, y: 380 },    // Right side, below API
+  'message-broker': { x: 820, y: 100 },   // Right side, top
+  'message-worker': { x: 500, y: 100 },   // Center, top
+  'otel': { x: 500, y: 570 },     // Center, below API
+  'immersive-apm': { x: 380, y: 510 },  // IAPM backend in sandbox
+  'immersive-apm-client': { x: 135, y: 490 },  // IAPM Desktop in dev workstation
+  'others': { x: 620, y: 510 },         // Others backend in sandbox
+  'others-client': { x: 135, y: 575 }   // Others client in dev workstation
 };
 
 @Component({
@@ -135,6 +137,14 @@ export class NetworkDiagramComponent implements OnInit, OnChanges, AfterViewInit
   sqlTelemetryDotProgress = 0;
   redisTelemetryDotVisible = false;
   redisTelemetryDotProgress = 0;
+
+  // Client dots (from APM backends to developer workstation)
+  iapmDesktopDotVisible = false;
+  iapmDesktopDotProgress = 0;
+  iapmWebDotVisible = false;
+  iapmWebDotProgress = 0;
+  othersClientDotVisible = false;
+  othersClientDotProgress = 0;
 
   // Status ticker - messages stack horizontally and linger
   statusMessages: { id: number; text: string; type: 'request' | 'telemetry'; step: number }[] = [];
@@ -602,6 +612,10 @@ export class NetworkDiagramComponent implements OnInit, OnChanges, AfterViewInit
     this.immersiveApmDotVisible = false;
     this.setNodeStatus('immersive-apm', 'idle');
     this.cdr.detectChanges();
+
+    // Continue to IAPM client tools (desktop and web in parallel)
+    this.animateToIapmClient('desktop');
+    this.animateToIapmClient('web');
   }
 
   private async animateToOthers(source: string = 'API'): Promise<void> {
@@ -624,6 +638,59 @@ export class NetworkDiagramComponent implements OnInit, OnChanges, AfterViewInit
     await this.delay(300);
     this.othersDotVisible = false;
     this.setNodeStatus('others', 'idle');
+    this.cdr.detectChanges();
+
+    // Continue to client tools
+    this.animateToOthersClient();
+  }
+
+  private async animateToIapmClient(target: 'desktop' | 'web' = 'desktop'): Promise<void> {
+    const steps = 25;
+    const stepDuration = 400 / steps;
+
+    if (target === 'desktop') {
+      this.iapmDesktopDotProgress = 0;
+      this.iapmDesktopDotVisible = true;
+      this.cdr.detectChanges();
+
+      for (let i = 0; i <= steps; i++) {
+        this.iapmDesktopDotProgress = i / steps;
+        this.cdr.detectChanges();
+        await this.delay(stepDuration);
+      }
+
+      this.iapmDesktopDotVisible = false;
+    } else {
+      this.iapmWebDotProgress = 0;
+      this.iapmWebDotVisible = true;
+      this.cdr.detectChanges();
+
+      for (let i = 0; i <= steps; i++) {
+        this.iapmWebDotProgress = i / steps;
+        this.cdr.detectChanges();
+        await this.delay(stepDuration);
+      }
+
+      this.iapmWebDotVisible = false;
+    }
+    this.cdr.detectChanges();
+  }
+
+  private async animateToOthersClient(): Promise<void> {
+    this.othersClientDotProgress = 0;
+    this.othersClientDotVisible = true;
+    this.cdr.detectChanges();
+
+    const steps = 30;
+    const stepDuration = 500 / steps;
+
+    for (let i = 0; i <= steps; i++) {
+      this.othersClientDotProgress = i / steps;
+      this.cdr.detectChanges();
+      await this.delay(stepDuration);
+    }
+
+    this.othersClientDotVisible = false;
     this.cdr.detectChanges();
   }
 
@@ -686,11 +753,11 @@ export class NetworkDiagramComponent implements OnInit, OnChanges, AfterViewInit
     };
   }
 
-  // Get SVG position for telemetry dot (follows line from API at y=300 to OTel at y=440)
+  // Get SVG position for telemetry dot (follows line from API to OTel)
   getTelemetryDotSvgPosition(): { x: number; y: number } {
-    // Line: x1="400" y1="300" x2="400" y2="440"
-    const from = { x: 400, y: 300 };
-    const to = { x: 400, y: 440 };
+    // Line: x1="500" y1="350" x2="500" y2="440"
+    const from = { x: 500, y: 350 };
+    const to = { x: 500, y: 440 };
 
     return {
       x: from.x + (to.x - from.x) * this.telemetryDotProgress,
@@ -698,11 +765,11 @@ export class NetworkDiagramComponent implements OnInit, OnChanges, AfterViewInit
     };
   }
 
-  // Get SVG position for Immersive APM dot (follows line from OTel at y=520 to IAPM at y=590)
+  // Get SVG position for Immersive APM dot (follows line from OTel to IAPM Cloud)
   getImmersiveApmDotSvgPosition(): { x: number; y: number } {
-    // Line: x1="400" y1="520" x2="280" y2="590"
-    const from = { x: 400, y: 520 };
-    const to = { x: 280, y: 590 };
+    // Line: x1="500" y1="530" x2="500" y2="545"
+    const from = { x: 500, y: 530 };
+    const to = { x: 500, y: 545 };
 
     return {
       x: from.x + (to.x - from.x) * this.immersiveApmDotProgress,
@@ -710,16 +777,49 @@ export class NetworkDiagramComponent implements OnInit, OnChanges, AfterViewInit
     };
   }
 
-  // Get SVG position for Others dot (follows line from OTel at y=520 to Others at y=590)
+  // Get SVG position for Others dot (follows line from OTel to Other Plumbing)
   getOthersDotSvgPosition(): { x: number; y: number } {
-    // Line: x1="400" y1="520" x2="520" y2="590"
-    const from = { x: 400, y: 520 };
-    const to = { x: 520, y: 590 };
+    // Line: x1="570" y1="500" x2="620" y2="570"
+    const from = { x: 570, y: 500 };
+    const to = { x: 620, y: 570 };
 
     return {
       x: from.x + (to.x - from.x) * this.othersDotProgress,
       y: from.y + (to.y - from.y) * this.othersDotProgress
     };
+  }
+
+  // Get SVG position for IAPM Desktop dot (follows line from IAPM Cloud to Desktop)
+  getIapmDesktopDotSvgPosition(): { x: number; y: number } {
+    // Desktop line: x1="430" y1="590" x2="255" y2="480"
+    const from = { x: 430, y: 590 };
+    const to = { x: 255, y: 480 };
+
+    return {
+      x: from.x + (to.x - from.x) * this.iapmDesktopDotProgress,
+      y: from.y + (to.y - from.y) * this.iapmDesktopDotProgress
+    };
+  }
+
+  // Get SVG position for IAPM Web dot (follows line from IAPM Cloud to Web)
+  getIapmWebDotSvgPosition(): { x: number; y: number } {
+    // Web line: x1="430" y1="600" x2="255" y2="545"
+    const from = { x: 430, y: 600 };
+    const to = { x: 255, y: 545 };
+
+    return {
+      x: from.x + (to.x - from.x) * this.iapmWebDotProgress,
+      y: from.y + (to.y - from.y) * this.iapmWebDotProgress
+    };
+  }
+
+  // Get SVG position for Others client dot (follows curved path from Other Plumbing to Other Tools)
+  getOthersClientDotSvgPosition(): { x: number; y: number } {
+    // Path: M 620 650 Q 400 750 255 595
+    const start = { x: 620, y: 650 };
+    const control = { x: 400, y: 750 };
+    const end = { x: 255, y: 595 };
+    return this.getQuadraticBezierPosition(start, control, end, this.othersClientDotProgress);
   }
 
   // Calculate position along a quadratic bezier curve
@@ -739,19 +839,19 @@ export class NetworkDiagramComponent implements OnInit, OnChanges, AfterViewInit
 
   // Get SVG position for SQL telemetry dot (along curved path)
   getSqlTelemetryDotSvgPosition(): { x: number; y: number } {
-    // Path: M 720 220 Q 620 400 400 470 (matches HTML)
-    const start = { x: 720, y: 220 };
-    const control = { x: 620, y: 400 };
-    const end = { x: 400, y: 470 };
+    // Path: M 820 270 Q 700 400 570 450 (matches HTML)
+    const start = { x: 820, y: 270 };
+    const control = { x: 700, y: 400 };
+    const end = { x: 570, y: 450 };
     return this.getQuadraticBezierPosition(start, control, end, this.sqlTelemetryDotProgress);
   }
 
   // Get SVG position for Redis telemetry dot (along curved path)
   getRedisTelemetryDotSvgPosition(): { x: number; y: number } {
-    // Path: M 720 350 Q 600 450 400 470 (matches HTML)
-    const start = { x: 720, y: 350 };
-    const control = { x: 600, y: 450 };
-    const end = { x: 400, y: 470 };
+    // Path: M 820 380 Q 680 420 570 460 (matches HTML)
+    const start = { x: 820, y: 380 };
+    const control = { x: 680, y: 420 };
+    const end = { x: 570, y: 460 };
     return this.getQuadraticBezierPosition(start, control, end, this.redisTelemetryDotProgress);
   }
 


### PR DESCRIPTION
- Fix telemetry photons to be blue (#425CC7) by removing CSS fill overrides
- Change all telemetry lines (OTel to backends and tools) to orange (#F5A623)
- Add parallel photon animations for IAPM Desktop and Web
- Update drop-shadow colors to match blue photons